### PR TITLE
Header cleanup

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
-[submodule "leveldv"]
-	path = leveldv
+[submodule "leveldb-library"]
+	path = leveldb-library
 	url = https://code.google.com/p/leveldb

--- a/Classes/LevelDB.h
+++ b/Classes/LevelDB.h
@@ -7,22 +7,13 @@
 
 #import <Foundation/Foundation.h>
 
-#import "leveldb/db.h"
-
-using namespace leveldb;
-
 typedef BOOL (^KeyBlock)(NSString *key);
 typedef BOOL (^KeyValueBlock)(NSString *key, id value);
 
-@interface LevelDB : NSObject {
-    DB *db;
-    ReadOptions readOptions;
-    WriteOptions writeOptions;
-}
+@interface LevelDB : NSObject
 
 @property (nonatomic, retain) NSString *path;
 
-+ (id)libraryPath;
 + (LevelDB *)databaseInLibraryWithName:(NSString *)name;
 
 - (id) initWithPath:(NSString *)path;

--- a/Classes/LevelDB.h
+++ b/Classes/LevelDB.h
@@ -14,7 +14,7 @@ typedef BOOL (^KeyValueBlock)(NSString *key, id value);
 
 @property (nonatomic, retain) NSString *path;
 
-+ (LevelDB *)databaseInLibraryWithName:(NSString *)name;
++ (instancetype)databaseInLibraryWithName:(NSString *)name;
 
 - (id) initWithPath:(NSString *)path;
 

--- a/Classes/LevelDB.mm
+++ b/Classes/LevelDB.mm
@@ -34,7 +34,12 @@ static id ObjectFromSlice(Slice v) {
     return object;
 }
 
-@implementation LevelDB 
+@implementation LevelDB {
+    DB *db;
+    ReadOptions readOptions;
+    WriteOptions writeOptions;
+}
+
 
 @synthesize path=_path;
 


### PR DESCRIPTION
Hi,

I removed the C++ dependency from the `LevelDB.h` header. I just moved the instance variables to the implementation file which allowed me to remove the `#import` and namespace declaration.

I did a couple of other small cleanups:
- Removed `+librarypath` from the header, it didn't need to be exposed
- Replaced `LevelDB *` return type in the class method with `instancetype`
- Fixed submodule reference and updated to the latest version.
